### PR TITLE
#23 - Implement "User: Ende" and "User: offene Fragen"

### DIFF
--- a/MYQuizClient/App.xaml.cs
+++ b/MYQuizClient/App.xaml.cs
@@ -11,7 +11,7 @@ namespace MYQuizClient
 		public App()
 		{
 			InitializeComponent();
-            var test = new Networking("https://jsonplaceholder.typicode.com");
+            var test = new Networking("http://jsonplaceholder.typicode.com");
             
             test.dummyRequest();
             test.dummyReceive();

--- a/MYQuizClient/MYQuizClient.csproj
+++ b/MYQuizClient/MYQuizClient.csproj
@@ -38,13 +38,14 @@
       <DependentUpon>LoginView.xaml</DependentUpon>
     </Compile>
     <Compile Include="Networking.cs" />
-
     <Compile Include="NotificationListener.cs" />
     <Compile Include="NotificationManager.cs" />
+    <Compile Include="PreSendView.xaml.cs">
+      <DependentUpon>PreSendView.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Helpers\Settings.cs" />
     <Compile Include="EmptyClass.cs" />
-    <Compile Include="AppSettings.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
@@ -86,6 +87,12 @@
   <ItemGroup>
     <EmbeddedResource Include="LoginView.xaml">
       <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="PreSendView.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
       <SubType>Designer</SubType>
     </EmbeddedResource>
   </ItemGroup>

--- a/MYQuizClient/PreSendView.xaml
+++ b/MYQuizClient/PreSendView.xaml
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="MYQuizClient.PreSendView"
+             >
+  <StackLayout VerticalOptions="Center" HorizontalOptions="Center">
+    <StackLayout x:Name="UserEnde">
+      <Label Text="Vielen Dank!" HorizontalTextAlignment="Center" Margin="0,0,0,100"/>
+      <Button Text="Fragebogen senden" BorderColor="Black"/>
+    </StackLayout>
+    <StackLayout x:Name="UserOffeneFragen" IsVisible="false">
+      <StackLayout VerticalOptions="Center" HorizontalOptions="Center">
+        <Label x:Name="lbl_fragen" Text="Offene Fragen" HorizontalTextAlignment="Center"/>
+        <BoxView BackgroundColor="Black" HeightRequest="1" Margin="0,-8,0,0" />
+      </StackLayout>
+      <Label Text="Achtung!&#x0a;Einige Fragen wurden&#x0a;nicht beantwortet.&#x0a;&#x0a;Trotzdem senden?" HorizontalTextAlignment="Center"/>
+      <StackLayout Orientation="Horizontal" Margin="0,20,0,0">
+        <Button Text="Ja" WidthRequest="75" BorderColor="Black"/>
+        <Button Text="Nein" WidthRequest="75" BorderColor="Black"/>
+      </StackLayout>
+    </StackLayout>
+  </StackLayout>
+</ContentPage>

--- a/MYQuizClient/PreSendView.xaml
+++ b/MYQuizClient/PreSendView.xaml
@@ -2,17 +2,15 @@
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="MYQuizClient.PreSendView"
+             Title="Offene Fragen"
              >
   <StackLayout VerticalOptions="Center" HorizontalOptions="Center">
-    <StackLayout x:Name="UserEnde">
+    <StackLayout x:Name="UserEnde" IsVisible="false">
       <Label Text="Vielen Dank!" HorizontalTextAlignment="Center" Margin="0,0,0,100"/>
       <Button Text="Fragebogen senden" BorderColor="Black"/>
     </StackLayout>
-    <StackLayout x:Name="UserOffeneFragen" IsVisible="false">
-      <StackLayout VerticalOptions="Center" HorizontalOptions="Center">
-        <Label x:Name="lbl_fragen" Text="Offene Fragen" HorizontalTextAlignment="Center"/>
-        <BoxView BackgroundColor="Black" HeightRequest="1" Margin="0,-8,0,0" />
-      </StackLayout>
+    <StackLayout x:Name="UserOffeneFragen">
+
       <Label Text="Achtung!&#x0a;Einige Fragen wurden&#x0a;nicht beantwortet.&#x0a;&#x0a;Trotzdem senden?" HorizontalTextAlignment="Center"/>
       <StackLayout Orientation="Horizontal" Margin="0,20,0,0">
         <Button Text="Ja" WidthRequest="75" BorderColor="Black"/>

--- a/MYQuizClient/PreSendView.xaml.cs
+++ b/MYQuizClient/PreSendView.xaml.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xamarin.Forms;
+
+namespace MYQuizClient
+{
+    public partial class PreSendView : ContentPage
+    {
+        public PreSendView()
+        {
+            InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
https doesn't work at the moment on android. Used http instead.

Xamarin.Forms Label doesn't contain Underlines. Used a visual equivalent solution for this problem.
Android Label color is gray but the underline is stil black because of this solution.

closes #23 